### PR TITLE
Theme dependent GitHub stats and Discord RPC cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 [![Reddit - u/sudoAlphaX](https://img.shields.io/badge/Reddit-u%2FsudoAlphaX-ff4500?logo=reddit&labelColor=white)](https://www.reddit.com/user/sudoAlphaX)
 
 <a href="https://github.com/sudoAlphaX">
-  <img height="201" align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=github_dark&bg_color=1a1c1f&hide_border=false&border_color=1a1c1f&rank_icon=default&card_width=381px&show=prs_merged,prs_merged_percentage" />
+  <img height="201" align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=github_dark&bg_color=1a1c1f&hide_border=false&border_color=1a1c1f&rank_icon=default&card_width=390px&show=prs_merged,prs_merged_percentage" />
 </a>&nbsp;
 <a href= "https://discord.com/users/705624271308849224">
   <img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=dark&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing..." />

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@
 <div>
   <span style="">💾 Download the key instead:</span>
   <a href="https://raw.githubusercontent.com/sudoAlphaX/sudoAlphaX/main/sudoAlpha.asc">
-    <img height="22" align="center" style="vertical-align:middle" alt="GNU Privacy Guard logo" src="https://img.shields.io/badge/GnuPG_Public_Key-333?style=for-the-badge&logo=GNU%20Privacy%20Guard&logoColor=0093DD">
+    <img height="22" style="vertical-align:middle" alt="GNU Privacy Guard logo" src="https://img.shields.io/badge/GnuPG_Public_Key-333?style=for-the-badge&logo=GNU%20Privacy%20Guard&logoColor=0093DD">
   </a>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 [![Reddit - u/sudoAlphaX](https://img.shields.io/badge/Reddit-u%2FsudoAlphaX-ff4500?logo=reddit&labelColor=white)](https://www.reddit.com/user/sudoAlphaX)
 
 <a href="https://github.com/sudoAlphaX">
-  <img height="201" align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=github_dark&bg_color=1a1c1f&hide_border=false&border_color=1a1c1f&rank_icon=default&card_width=390px&show=prs_merged,prs_merged_percentage" />
+  <img height="201" align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=github_dark&bg_color=1a1c1f&hide_border=false&border_color=1a1c1f&rank_icon=default&card_width=381px&show=prs_merged,prs_merged_percentage" />
 </a>&nbsp;
 <a href= "https://discord.com/users/705624271308849224">
   <img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=dark&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing..." />

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@
 [![Instagram - @sudoalphax](https://img.shields.io/badge/Instagram-%40sudoalphax-deeppink?logo=instagram)](https://www.instagram.com/sudoalphax)
 [![Reddit - u/sudoAlphaX](https://img.shields.io/badge/Reddit-u%2FsudoAlphaX-ff4500?logo=reddit&labelColor=white)](https://www.reddit.com/user/sudoAlphaX)
 
-<a href="https://github.com/sudoAlphaX">
+<a href="https://github.com/sudoAlphaX#gh-dark-mode-only">
   <img height="201" align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=github_dark&bg_color=1a1c1f&hide_border=false&border_color=1a1c1f&rank_icon=default&card_width=381px&show=prs_merged,prs_merged_percentage#gh-dark-mode-only" />
 </a>&nbsp;
-<a href= "https://discord.com/users/705624271308849224">
+<a href= "https://discord.com/users/705624271308849224#gh-dark-mode-only">
   <img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=dark&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing...#gh-dark-mode-only" />
 </a>
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,12 @@
 [![Instagram - @sudoalphax](https://img.shields.io/badge/Instagram-%40sudoalphax-deeppink?logo=instagram)](https://www.instagram.com/sudoalphax)
 [![Reddit - u/sudoAlphaX](https://img.shields.io/badge/Reddit-u%2FsudoAlphaX-ff4500?logo=reddit&labelColor=white)](https://www.reddit.com/user/sudoAlphaX)
 
-<img height="201" align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=github_dark&bg_color=1a1c1f&hide_border=false&border_color=1a1c1f&rank_icon=default&card_width=381px&show=prs_merged,prs_merged_percentage#gh-dark-mode-only" />&nbsp;
-<img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=dark&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing...#gh-dark-mode-only" />
+<a href="https://github.com/sudoAlphaX#gh-dark-mode-only">
+  <img height="201" align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=github_dark&bg_color=1a1c1f&hide_border=false&border_color=1a1c1f&rank_icon=default&card_width=381px&show=prs_merged,prs_merged_percentage" />
+</a>&nbsp;
+<a href= "https://discord.com/users/705624271308849224#gh-dark-mode-only">
+  <img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=dark&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing..." />
+</a>
 
 <hr>
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![SudoAlphaX GitHub User stars](https://img.shields.io/github/stars/sudoAlphaX?color=yellow&label=Stars&affiliations=OWNER)
 [![sudoAlphaX GitHub followers](https://img.shields.io/github/followers/sudoAlphaX?color=green&label=Followers)](https://github.com/sudoAlphaX?tab=followers)
-![sudoAlphaX GitHub Profile Views](https://komarev.com/ghpvc/?username=your-sudoAlphaX&label=Profile+views)
+<!-- ![sudoAlphaX GitHub Profile Views](https://komarev.com/ghpvc/?username=your-sudoAlphaX&label=Profile+views) -->
 
 - 💻 Coding as a hobby
 
@@ -19,10 +19,10 @@
 [![Reddit - u/sudoAlphaX](https://img.shields.io/badge/Reddit-u%2FsudoAlphaX-ff4500?logo=reddit&labelColor=white)](https://www.reddit.com/user/sudoAlphaX)
 
 <a href="https://github.com/sudoAlphaX">
-  <img height="201"align="center" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=github_dark&show=prs_merged,prs_merged_percentage" />
-</a>
+  <img height="201" align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=github_dark&bg_color=1a1c1f&hide_border=false&border_color=1a1c1f&rank_icon=default&card_width=381px&show=prs_merged,prs_merged_percentage" />
+</a>&nbsp;
 <a href= "https://discord.com/users/705624271308849224">
-  <img height="200" align="center" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=dark&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing..." />
+  <img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=dark&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing..." />
 </a>
 
 <hr>

--- a/README.md
+++ b/README.md
@@ -18,12 +18,8 @@
 [![Instagram - @sudoalphax](https://img.shields.io/badge/Instagram-%40sudoalphax-deeppink?logo=instagram)](https://www.instagram.com/sudoalphax)
 [![Reddit - u/sudoAlphaX](https://img.shields.io/badge/Reddit-u%2FsudoAlphaX-ff4500?logo=reddit&labelColor=white)](https://www.reddit.com/user/sudoAlphaX)
 
-<a href="https://github.com/sudoAlphaX#gh-dark-mode-only">
-  <img height="201" align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=github_dark&bg_color=1a1c1f&hide_border=false&border_color=1a1c1f&rank_icon=default&card_width=381px&show=prs_merged,prs_merged_percentage" />
-</a>&nbsp;
-<a href= "https://discord.com/users/705624271308849224#gh-dark-mode-only">
-  <img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=dark&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing..." />
-</a>
+<img height="201" align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=github_dark&bg_color=1a1c1f&hide_border=false&border_color=1a1c1f&rank_icon=default&card_width=381px&show=prs_merged,prs_merged_percentage#gh-dark-mode-only" />&nbsp;
+<img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=dark&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing...#gh-dark-mode-only" />
 
 <hr>
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@
 <div>
   <span style="">💾 Download the key instead:</span>
   <a href="https://raw.githubusercontent.com/sudoAlphaX/sudoAlphaX/main/sudoAlpha.asc">
-    <img height="22" style="vertical-align:middle" alt="GNU Privacy Guard logo" src="https://img.shields.io/badge/GnuPG_Public_Key-333?style=for-the-badge&logo=GNU%20Privacy%20Guard&logoColor=0093DD">
+    <img height="22" align="center" style="vertical-align:middle" alt="GNU Privacy Guard logo" src="https://img.shields.io/badge/GnuPG_Public_Key-333?style=for-the-badge&logo=GNU%20Privacy%20Guard&logoColor=0093DD">
   </a>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@
 [![Reddit - u/sudoAlphaX](https://img.shields.io/badge/Reddit-u%2FsudoAlphaX-ff4500?logo=reddit&labelColor=white)](https://www.reddit.com/user/sudoAlphaX)
 
 <a href="https://github.com/sudoAlphaX#gh-dark-mode-only">
-  <img height="201" align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=github_dark&bg_color=1a1c1f&hide_border=false&border_color=1a1c1f&rank_icon=default&card_width=381px&show=prs_merged,prs_merged_percentage#gh-dark-mode-only" />
+  <img height="201" align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=github_dark&bg_color=1a1c1f&hide_border=false&border_color=1a1c1f&rank_icon=default&card_width=381px&show=prs_merged,prs_merged_percentage" />
 </a>&nbsp;
 <a href= "https://discord.com/users/705624271308849224#gh-dark-mode-only">
-  <img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=dark&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing...#gh-dark-mode-only" />
+  <img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=dark&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing..." />
 </a>
 
 <hr>

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
   <img height="201" align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=default&bg_color=ffffff&hide_border=false&border_color=ffffff&rank_icon=default&card_width=381px&show=prs_merged,prs_merged_percentage" />
 </a>&nbsp;
 <a href= "https://discord.com/users/705624271308849224#gh-light-mode-only">
-  <img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=light&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing..." />
+  <img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=light&bg=ffffff&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing..." />
 </a>
 
 <hr>

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
   <img height="201" align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=default&bg_color=ffffff&hide_border=false&border_color=ffffff&rank_icon=default&card_width=381px&show=prs_merged,prs_merged_percentage" />
 </a>&nbsp;
 <a href= "https://discord.com/users/705624271308849224#gh-light-mode-only">
-  <img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=light&bg=ffffff&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing..." />
+  <img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=light&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing..." />
 </a>
 
 <hr>

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@
   <img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=dark&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing..." />
 </a>
 
+<a href="https://github.com/sudoAlphaX#gh-light-mode-only">
+  <img height="201" align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=default&bg_color=ffffff&hide_border=false&border_color=1a1c1f&rank_icon=default&card_width=381px&show=prs_merged,prs_merged_percentage" />
+</a>&nbsp;
+<a href= "https://discord.com/users/705624271308849224#gh-light-mode-only">
+  <img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=light&bg=ffffff&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing..." />
+</a>
+
 <hr>
 
 <h1 align="left">My skills</h1>

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 </a>
 
 <a href="https://github.com/sudoAlphaX#gh-light-mode-only">
-  <img height="201" align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=default&bg_color=ffffff&hide_border=false&border_color=1a1c1f&rank_icon=default&card_width=381px&show=prs_merged,prs_merged_percentage" />
+  <img height="201" align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=default&bg_color=ffffff&hide_border=false&border_color=ffffff&rank_icon=default&card_width=381px&show=prs_merged,prs_merged_percentage" />
 </a>&nbsp;
 <a href= "https://discord.com/users/705624271308849224#gh-light-mode-only">
   <img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=light&bg=ffffff&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing..." />

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@
 [![Reddit - u/sudoAlphaX](https://img.shields.io/badge/Reddit-u%2FsudoAlphaX-ff4500?logo=reddit&labelColor=white)](https://www.reddit.com/user/sudoAlphaX)
 
 <a href="https://github.com/sudoAlphaX">
-  <img height="201" align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=github_dark&bg_color=1a1c1f&hide_border=false&border_color=1a1c1f&rank_icon=default&card_width=381px&show=prs_merged,prs_merged_percentage" />
+  <img height="201" align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=github_dark&bg_color=1a1c1f&hide_border=false&border_color=1a1c1f&rank_icon=default&card_width=381px&show=prs_merged,prs_merged_percentage#gh-dark-mode-only" />
 </a>&nbsp;
 <a href= "https://discord.com/users/705624271308849224">
-  <img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=dark&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing..." />
+  <img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=dark&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing...#gh-dark-mode-only" />
 </a>
 
 <hr>


### PR DESCRIPTION
use #gh-dark-mode-only and #gh-light-mode-only in the end of urls to apply dark stats card for dark theme users and light stats cards for light theme users.