### PR TITLE
Themed-elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,45 @@
 📫 Contact me:
 
 <p>
-<a href="https://discord.com/users/705624271308849224#gh-dark-mode-only"><img src="https://img.shields.io/badge/Discord-sudoalpha-5865f2?logo=discord&labelColor=grey" alt="Discord - sudoalpha"></a>
-<a href="https://t.me/su_Alpha#gh-dark-mode-only"><img src="https://img.shields.io/badge/Telegram-%40su__Alpha-24a1de?logo=telegram&labelColor=grey" alt="Telegram - @su_Alpha"></a>
-<a href="https://twitter.com/sudoAlphaX#gh-dark-mode-only"><img src="https://img.shields.io/twitter/follow/sudoalphax?label=%40sudoAlphaX" alt="X (Twitter) - @sudoAlphaX"></a>
-<a href="https://www.instagram.com/sudoalphax#gh-dark-mode-only"><img src="https://img.shields.io/badge/Instagram-%40sudoalphax-deeppink?logo=instagram&labelColor=ffffff" alt="Instagram - @sudoalphax"></a>
-<a href="https://www.reddit.com/user/sudoAlphaX#gh-dark-mode-only"><img src="https://img.shields.io/badge/Reddit-u%2FsudoAlphaX-ff4500?logo=reddit&labelColor=ffffff" alt="Reddit - u/sudoAlphaX"></a>
-</p>
+  <a href = "https://discord.com/users/705624271308849224">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Discord-sudoalpha-5865f2?logo=discord&labelColor=grey">
+      <source media="(prefers-color-scheme: light)" srcset="https://img.shields.io/badge/Discord-sudoalpha-5865f2?logo=discord&labelColor=ffffff">
+      <img src="https://img.shields.io/badge/Discord-sudoalpha-5865f2?logo=discord&labelColor=ffffff" alt="Discord - sudoalpha">
+    </picture>
+  </a>
 
-<p>
-<a href="https://discord.com/users/705624271308849224#gh-light-mode-only"><img src="https://img.shields.io/badge/Discord-sudoalpha-5865f2?logo=discord&labelColor=ffffff" alt="Discord - sudoalpha"></a>
-<a href="https://t.me/su_Alpha#gh-light-mode-only"><img src="https://img.shields.io/badge/Telegram-%40su__Alpha-24a1de?logo=telegram&labelColor=ffffff" alt="Telegram - @su_Alpha"></a>
-<a href="https://twitter.com/sudoAlphaX#gh-light-mode-only"><img src="https://img.shields.io/twitter/follow/sudoalphax?label=%40sudoAlphaX" alt="X (Twitter) - @sudoAlphaX"></a>
-<a href="https://www.instagram.com/sudoalphax#gh-light-mode-only"><img src="https://img.shields.io/badge/Instagram-%40sudoalphax-deeppink?logo=instagram&labelColor=ffffff" alt="Instagram - @sudoalphax"></a>
-<a href="https://www.reddit.com/user/sudoAlphaX#gh-light-mode-only"><img src="https://img.shields.io/badge/Reddit-u%2FsudoAlphaX-ff4500?logo=reddit&labelColor=ffffff" alt="Reddit - u/sudoAlphaX"></a>
+  <a href = "https://t.me/su_Alpha">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Telegram-%40su__Alpha-24a1de?logo=telegram&labelColor=grey">
+      <source media="(prefers-color-scheme: light)" srcset="https://img.shields.io/badge/Telegram-%40su__Alpha-24a1de?logo=telegram&labelColor=ffffff">
+      <img src="https://img.shields.io/badge/Telegram-%40su__Alpha-24a1de?logo=telegram&labelColor=ffffff" alt="Telegram - @su_Alpha">
+    </picture>
+  </a>
+
+  <a href = "https://twitter.com/sudoAlphaX">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/twitter/follow/sudoalphax?label=%40sudoAlphaX">
+      <source media="(prefers-color-scheme: light)" srcset="https://img.shields.io/twitter/follow/sudoalphax?label=%40sudoAlphaX">
+      <img src="https://img.shields.io/twitter/follow/sudoalphax?label=%40sudoAlphaX" alt="X (Twitter) - @sudoAlphaX">
+    </picture>
+  </a>
+
+  <a href = "https://www.instagram.com/sudoalphax">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Instagram-%40sudoalphax-deeppink?logo=instagram&labelColor=ffffff">
+      <source media="(prefers-color-scheme: light)" srcset="https://img.shields.io/badge/Instagram-%40sudoalphax-deeppink?logo=instagram&labelColor=ffffff">
+      <img src="https://img.shields.io/badge/Instagram-%40sudoalphax-deeppink?logo=instagram&labelColor=ffffff" alt="Instagram - @sudoalphax">
+    </picture>
+  </a>
+
+  <a href = "https://www.reddit.com/u/sudoAlphaX">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Reddit-u%2FsudoAlphaX-ff4500?logo=reddit&labelColor=ffffff">
+      <source media="(prefers-color-scheme: light)" srcset="https://img.shields.io/badge/Reddit-u%2FsudoAlphaX-ff4500?logo=reddit&labelColor=ffffff">
+      <img src="https://img.shields.io/badge/Reddit-u%2FsudoAlphaX-ff4500?logo=reddit&labelColor=ffffff" alt="Reddit - u/sudoAlphaX">
+    </picture>
+  </a>
 </p>
 
 <a href="https://github.com/sudoAlphaX/sudoAlphaX/blob/main/STATS.md#gh-dark-mode-only">

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ View additional statistics in <a href=https://github.com/sudoAlphaX/sudoAlphaX/b
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=python&theme=dark">
       <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=python&theme=light">
-      <img src="https://skillicons.dev/icons?i=python&theme=light">
+      <img src="https://skillicons.dev/icons?i=python&theme=light" alt="Python">
     </picture>
   </a>
 
@@ -65,7 +65,7 @@ View additional statistics in <a href=https://github.com/sudoAlphaX/sudoAlphaX/b
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=mongodb&theme=dark">
       <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=mongodb&theme=light">
-      <img src="https://skillicons.dev/icons?i=mongodb&theme=light">
+      <img src="https://skillicons.dev/icons?i=mongodb&theme=light" alt="MongoDB">
     </picture>
   </a>
 
@@ -73,7 +73,7 @@ View additional statistics in <a href=https://github.com/sudoAlphaX/sudoAlphaX/b
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=git&theme=dark">
       <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=git&theme=light">
-      <img src="https://skillicons.dev/icons?i=git&theme=light">
+      <img src="https://skillicons.dev/icons?i=git&theme=light" alt="Git">
     </picture>
   </a>
 
@@ -81,7 +81,7 @@ View additional statistics in <a href=https://github.com/sudoAlphaX/sudoAlphaX/b
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=github&theme=dark">
       <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=github&theme=light">
-      <img src="https://skillicons.dev/icons?i=github&theme=light">
+      <img src="https://skillicons.dev/icons?i=github&theme=light" alt="GitHub">
     </picture>
   </a>
 
@@ -89,7 +89,7 @@ View additional statistics in <a href=https://github.com/sudoAlphaX/sudoAlphaX/b
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=arduino&theme=dark">
       <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=arduino&theme=light">
-      <img src="https://skillicons.dev/icons?i=arduino&theme=light">
+      <img src="https://skillicons.dev/icons?i=arduino&theme=light" alt="Arduino">
     </picture>
   </a>
 </p>
@@ -102,7 +102,7 @@ View additional statistics in <a href=https://github.com/sudoAlphaX/sudoAlphaX/b
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=linux&theme=dark">
       <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=linux&theme=light">
-      <img src="https://skillicons.dev/icons?i=linux&theme=light">
+      <img src="https://skillicons.dev/icons?i=linux&theme=light" alt="Linux">
     </picture>
   </a>
 
@@ -110,7 +110,7 @@ View additional statistics in <a href=https://github.com/sudoAlphaX/sudoAlphaX/b
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=bash&theme=dark">
       <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=bash&theme=light">
-      <img src="https://skillicons.dev/icons?i=bash&theme=light">
+      <img src="https://skillicons.dev/icons?i=bash&theme=light" alt="Bash">
     </picture>
   </a>
 
@@ -118,7 +118,7 @@ View additional statistics in <a href=https://github.com/sudoAlphaX/sudoAlphaX/b
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=powershell&theme=dark">
       <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=powershell&theme=light">
-      <img src="https://skillicons.dev/icons?i=powershell&theme=light">
+      <img src="https://skillicons.dev/icons?i=powershell&theme=light" alt="PowerShell">
     </picture>
   </a>
 </p>
@@ -131,7 +131,7 @@ View additional statistics in <a href=https://github.com/sudoAlphaX/sudoAlphaX/b
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=go&theme=dark">
       <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=go&theme=light">
-      <img src="https://skillicons.dev/icons?i=go&theme=light">
+      <img src="https://skillicons.dev/icons?i=go&theme=light" alt="Go">
     </picture>
   </a>
 
@@ -139,7 +139,7 @@ View additional statistics in <a href=https://github.com/sudoAlphaX/sudoAlphaX/b
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=ts&theme=dark">
       <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=ts&theme=light">
-      <img src="https://skillicons.dev/icons?i=ts&theme=light">
+      <img src="https://skillicons.dev/icons?i=ts&theme=light" alt="TypeScript">
     </picture>
   </a>
 
@@ -147,7 +147,7 @@ View additional statistics in <a href=https://github.com/sudoAlphaX/sudoAlphaX/b
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=rust&theme=dark">
       <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=rust&theme=light">
-      <img src="https://skillicons.dev/icons?i=rust&theme=light">
+      <img src="https://skillicons.dev/icons?i=rust&theme=light" alt="Rust">
     </picture>
   </a>
 
@@ -155,7 +155,7 @@ View additional statistics in <a href=https://github.com/sudoAlphaX/sudoAlphaX/b
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=flask&theme=dark">
       <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=flask&theme=light">
-      <img src="https://skillicons.dev/icons?i=flask&theme=light">
+      <img src="https://skillicons.dev/icons?i=flask&theme=light" alt="Flask">
     </picture>
   </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -162,12 +162,17 @@ View additional statistics in <a href=https://github.com/sudoAlphaX/sudoAlphaX/b
 
 <h2>Socials</h2>
 
-<p align="left">
-  <a href = https://twitter.com/sudoAlphaX#gh-dark-mode-only><img src="https://raw.githubusercontent.com/dheereshagrwal/colored-icons/master/public/icons/x/x-light.svg" width=46 /></a>
-  <a href = https://twitter.com/sudoAlphaX#gh-light-mode-only><img src="https://raw.githubusercontent.com/dheereshagrwal/colored-icons/master/public/icons/x/x.svg" width=46 /></a>&nbsp;
-  <a href = https://www.reddit.com/r/sudoAlphaX><img src="https://raw.githubusercontent.com/dheereshagrwal/colored-icons/master/public/icons/reddit/reddit.svg" width=46 /></a>&nbsp;
-  <a href = https://www.instagram.com/sudoAlphaX><img src="https://raw.githubusercontent.com/dheereshagrwal/colored-icons/master/public/icons/instagram/instagram.svg" width=46 /></a>&nbsp;
-  <a href = https://t.me/sudoalphax><img src="https://raw.githubusercontent.com/dheereshagrwal/colored-icons/master/public/icons/telegram/telegram2.svg" width=46 /></a>
+<p>
+  <a href = "https://twitter.com/sudoAlphaX">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/dheereshagrwal/colored-icons/master/public/icons/x/x-light.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/dheereshagrwal/colored-icons/master/public/icons/x/x.svg">
+      <img src="https://raw.githubusercontent.com/dheereshagrwal/colored-icons/master/public/icons/x/x.svg" width=46 alt="X (Twitter) - @sudoAlphaX">
+    </picture>
+  </a>
+  <a href = https://www.reddit.com/r/sudoAlphaX><img src="https://raw.githubusercontent.com/dheereshagrwal/colored-icons/master/public/icons/reddit/reddit.svg" width=46 alt="Reddit - r/sudoAlphaX"/></a>&nbsp;
+  <a href = https://www.instagram.com/sudoAlphaX><img src="https://raw.githubusercontent.com/dheereshagrwal/colored-icons/master/public/icons/instagram/instagram.svg" width=46 alt="Instagram - @sudoAlphaX"/></a>&nbsp;
+  <a href = https://t.me/sudoalphax><img src="https://raw.githubusercontent.com/dheereshagrwal/colored-icons/master/public/icons/telegram/telegram2.svg" width=46 alt="Telegram - @sudoAlphaX"/></a>
 </p>
 
 <hr>

--- a/README.md
+++ b/README.md
@@ -49,34 +49,118 @@
 View additional statistics in <a href=https://github.com/sudoAlphaX/sudoAlphaX/blob/main/STATS.md>STATS.md</a> file.
 <hr>
 
-<h1 align="left">My skills</h1>
 
-<p align="left">
-<a href=https://www.python.org><img src="https://skillicons.dev/icons?i=python" /></a>&nbsp;
-<a href=https://www.mongodb.com><img src="https://skillicons.dev/icons?i=mongodb" /></a>&nbsp;
-<a href=https://git-scm.com><img src="https://skillicons.dev/icons?i=git" /></a>&nbsp;
-<a href=https://www.github.com><img src="https://skillicons.dev/icons?i=github" /></a>&nbsp;
-<a href=https://www.arduino.cc><img src="https://skillicons.dev/icons?i=arduino" /></a>
+<h2>My skills</h2>
+
+<p>
+  <a href = "https://www.python.org">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=python&theme=dark">
+      <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=python&theme=light">
+      <img src="https://skillicons.dev/icons?i=python&theme=light">
+    </picture>
+  </a>
+
+  <a href = "https://www.mongodb.com">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=mongodb&theme=dark">
+      <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=mongodb&theme=light">
+      <img src="https://skillicons.dev/icons?i=mongodb&theme=light">
+    </picture>
+  </a>
+
+  <a href = "https://git-scm.com">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=git&theme=dark">
+      <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=git&theme=light">
+      <img src="https://skillicons.dev/icons?i=git&theme=light">
+    </picture>
+  </a>
+
+  <a href = "https://www.github.com">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=github&theme=dark">
+      <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=github&theme=light">
+      <img src="https://skillicons.dev/icons?i=github&theme=light">
+    </picture>
+  </a>
+
+  <a href = "https://www.arduino.cc">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=arduino&theme=dark">
+      <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=arduino&theme=light">
+      <img src="https://skillicons.dev/icons?i=arduino&theme=light">
+    </picture>
+  </a>
 </p>
 
-<h1 align="left">Currently learning</h1>
 
-<p align="left">
-<a href=https://www.linux.org><img src="https://skillicons.dev/icons?i=linux" /></a>&nbsp;
-<a href=https://www.gnu.org/software/bash><img src="https://skillicons.dev/icons?i=bash" /></a>&nbsp;
-<a href=https://learn.microsoft.com/en-us/powershell><img src="https://skillicons.dev/icons?i=powershell" /></a>
+<h2>Currently learning</h2>
+
+<p>
+  <a href = "https://www.linux.org">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=linux&theme=dark">
+      <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=linux&theme=light">
+      <img src="https://skillicons.dev/icons?i=linux&theme=light">
+    </picture>
+  </a>
+
+  <a href = "https://www.gnu.org/software/bash">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=bash&theme=dark">
+      <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=bash&theme=light">
+      <img src="https://skillicons.dev/icons?i=bash&theme=light">
+    </picture>
+  </a>
+
+  <a href = "https://learn.microsoft.com/en-us/powershell">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=powershell&theme=dark">
+      <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=powershell&theme=light">
+      <img src="https://skillicons.dev/icons?i=powershell&theme=light">
+    </picture>
+  </a>
 </p>
 
-<h1 align="left">Bucket list</h1>
 
-<p align="left">
-<a href=https://go.dev><img src="https://skillicons.dev/icons?i=go" /></a>&nbsp;
-<a href=https://www.typescriptlang.org><img src="https://skillicons.dev/icons?i=ts" /></a>&nbsp;
-<a href=https://www.rust-lang.org><img src="https://skillicons.dev/icons?i=rust" /></a>&nbsp;
-<a href=https://flask.palletsprojects.com><img src="https://skillicons.dev/icons?i=flask" /></a>
+<h2>Bucket list</h2>
+
+<p>
+  <a href = "https://go.dev">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=go&theme=dark">
+      <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=go&theme=light">
+      <img src="https://skillicons.dev/icons?i=go&theme=light">
+    </picture>
+  </a>
+
+  <a href = "https://www.typescriptlang.org">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=ts&theme=dark">
+      <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=ts&theme=light">
+      <img src="https://skillicons.dev/icons?i=ts&theme=light">
+    </picture>
+  </a>
+
+  <a href = "https://www.rust-lang.org">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=rust&theme=dark">
+      <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=rust&theme=light">
+      <img src="https://skillicons.dev/icons?i=rust&theme=light">
+    </picture>
+  </a>
+
+  <a href = "https://flask.palletsprojects.com">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://skillicons.dev/icons?i=flask&theme=dark">
+      <source media="(prefers-color-scheme: light)" srcset="https://skillicons.dev/icons?i=flask&theme=light">
+      <img src="https://skillicons.dev/icons?i=flask&theme=light">
+    </picture>
+  </a>
 </p>
 
-<h1 align="left">Socials</h1>
+<h2>Socials</h2>
 
 <p align="left">
   <a href = https://twitter.com/sudoAlphaX#gh-dark-mode-only><img src="https://raw.githubusercontent.com/dheereshagrwal/colored-icons/master/public/icons/x/x-light.svg" width=46 /></a>

--- a/README.md
+++ b/README.md
@@ -57,21 +57,25 @@
   </a>
 </p>
 
-<a href="https://github.com/sudoAlphaX/sudoAlphaX/blob/main/STATS.md#gh-dark-mode-only">
-  <img height="201" align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=github_dark&bg_color=1a1c1f&hide_border=false&border_color=1a1c1f&rank_icon=default&card_width=381px&show=prs_merged,prs_merged_percentage" />
-</a>&nbsp;
-<a href= "https://discord.com/users/705624271308849224#gh-dark-mode-only">
-  <img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=dark&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing..." />
-</a>
 
-<a href="https://github.com/sudoAlphaX/sudoAlphaX/blob/main/STATS.md#gh-light-mode-only">
-  <img height="201" align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=default&bg_color=ffffff&hide_border=false&border_color=ffffff&rank_icon=default&card_width=381px&show=prs_merged,prs_merged_percentage" />
-</a>&nbsp;
-<a href= "https://discord.com/users/705624271308849224#gh-light-mode-only">
-  <img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=light&bg=ffffff&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing..." />
-</a>
+<p>
+  <a href = "https://github.com/sudoAlphaX/sudoAlphaX/blob/main/STATS.md">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=github_dark&bg_color=1a1c1f&hide_border=false&border_color=1a1c1f&rank_icon=default&card_width=381px&show=prs_merged,prs_merged_percentage">
+      <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=default&bg_color=ffffff&hide_border=false&border_color=ffffff&rank_icon=default&card_width=381px&show=prs_merged,prs_merged_percentage">
+      <img height="201" align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=default&bg_color=ffffff&hide_border=false&border_color=ffffff&rank_icon=default&card_width=381px&show=prs_merged,prs_merged_percentage" alt="GitHub Stats">
+    </picture>
+  </a>&nbsp;
 
-<br>
+  <a href = "https://discord.com/users/705624271308849224">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://lanyard.cnrad.dev/api/705624271308849224?theme=dark&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing...">
+      <source media="(prefers-color-scheme: light)" srcset="https://lanyard.cnrad.dev/api/705624271308849224?theme=light&bg=ffffff&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing...">
+      <img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=light&bg=ffffff&showDisplayName=true&hideBadges=true&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing..." alt="Discord Rich Presence">
+    </picture>
+  </a>
+</p>
+
 View additional statistics in <a href=https://github.com/sudoAlphaX/sudoAlphaX/blob/main/STATS.md>STATS.md</a> file.
 <hr>
 

--- a/STATS.md
+++ b/STATS.md
@@ -7,11 +7,10 @@
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=github_dark&hide_border=false&include_all_commits=true&rank_icon=percentile&number_format=long&show=reviews,discussions_started,discussions_answered,prs_merged,prs_merged_percentage">
       <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=vue&hide_border=false&include_all_commits=true&rank_icon=percentile&number_format=long&show=reviews,discussions_started,discussions_answered,prs_merged,prs_merged_percentage">
-      <img src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=vue&hide_border=false&include_all_commits=true&rank_icon=percentile&number_format=long&show=reviews,discussions_started,discussions_answered,prs_merged,prs_merged_percentage">
+      <img align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=vue&hide_border=false&include_all_commits=true&rank_icon=percentile&number_format=long&show=reviews,discussions_started,discussions_answered,prs_merged,prs_merged_percentage">
     </picture>
   </a>
 </p>
-
 
 ## Most Used Languages
 
@@ -20,7 +19,7 @@
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=sudoalphax&custom_title=Alpha&apos;s%20Most%20Used%20Languages&layout=normal&langs_count=10&theme=github_dark&card_width=300">
       <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=sudoalphax&custom_title=Alpha&apos;s%20Most%20Used%20Languages&layout=normal&langs_count=10&theme=vue&card_width=300">
-      <img height="350" src="https://github-readme-stats.vercel.app/api/top-langs/?username=sudoalphax&custom_title=Alpha&apos;s%20Most%20Used%20Languages&layout=normal&langs_count=10&theme=vue&card_width=300">
+      <img align="top" height="350" src="https://github-readme-stats.vercel.app/api/top-langs/?username=sudoalphax&custom_title=Alpha&apos;s%20Most%20Used%20Languages&layout=normal&langs_count=10&theme=vue&card_width=300">
     </picture>
   </a>
 
@@ -28,7 +27,7 @@
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=sudoalphax&custom_title=Alpha&apos;s%20Most%20Used%20Languages&layout=donut-vertical&langs_count=10&theme=github_dark">
       <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=sudoalphax&custom_title=Alpha&apos;s%20Most%20Used%20Languages&layout=donut-vertical&langs_count=10&theme=vue">
-      <img height="350" src="https://github-readme-stats.vercel.app/api/top-langs/?username=sudoalphax&custom_title=Alpha&apos;s%20Most%20Used%20Languages&layout=donut-vertical&langs_count=10&theme=vue" >
+      <img align="top" height="350" src="https://github-readme-stats.vercel.app/api/top-langs/?username=sudoalphax&custom_title=Alpha&apos;s%20Most%20Used%20Languages&layout=donut-vertical&langs_count=10&theme=vue" >
     </picture>
   </a>
 </p>
@@ -41,7 +40,7 @@
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api/wakatime?username=sudoAlphaX&theme=github_dark&custom_title=Alpha&apos;s%20WakaTime%20Stats&layout=default&langs_count=10">
       <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api/wakatime?username=sudoAlphaX&theme=vue&custom_title=Alpha&apos;s%20Wakatime%20Stats&layout=default%display_format=time&langs_count=10">
-      <img src="https://github-readme-stats.vercel.app/api/wakatime?username=sudoAlphaX&theme=vue&custom_title=Alpha&apos;s%20Wakatime%20Stats&layout=default%display_format=time&langs_count=10">
+      <img align="top" src="https://github-readme-stats.vercel.app/api/wakatime?username=sudoAlphaX&theme=vue&custom_title=Alpha&apos;s%20Wakatime%20Stats&layout=default%display_format=time&langs_count=10">
     </picture>
   </a>
 
@@ -49,7 +48,7 @@
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api/wakatime?username=sudoAlphaX&theme=github_dark&custom_title=Alpha&apos;s%20WakaTime%20Stats&layout=compact&display_format=percent&langs_count=10">
       <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api/wakatime?username=sudoAlphaX&theme=vue&custom_title=Alpha&apos;s%20WakaTime%20Stats&layout=compact&display_format=percent&langs_count=10">
-      <img src="https://github-readme-stats.vercel.app/api/wakatime?username=sudoAlphaX&theme=vue&custom_title=Alpha&apos;s%20WakaTime%20Stats&layout=compact&display_format=percent&langs_count=10">
+      <img align="top" src="https://github-readme-stats.vercel.app/api/wakatime?username=sudoAlphaX&theme=vue&custom_title=Alpha&apos;s%20WakaTime%20Stats&layout=compact&display_format=percent&langs_count=10">
     </picture>
   </a>
 </p>
@@ -62,7 +61,7 @@
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://streak-stats.demolab.com?user=sudoAlphaX&theme=github-dark-blue&date_format=j%20M%5B%20Y%5D&card_width=300&hide_current_streak=true&hide_longest_streak=true">
       <source media="(prefers-color-scheme: light)" srcset="https://streak-stats.demolab.com?user=sudoAlphaX&theme=vue&date_format=j%20M%5B%20Y%5D&card_width=300&hide_current_streak=true&hide_longest_streak=true">
-      <img src="https://streak-stats.demolab.com?user=sudoAlphaX&theme=vue&date_format=j%20M%5B%20Y%5D&card_width=300&hide_current_streak=true&hide_longest_streak=true">
+      <img align="top" src="https://streak-stats.demolab.com?user=sudoAlphaX&theme=vue&date_format=j%20M%5B%20Y%5D&card_width=300&hide_current_streak=true&hide_longest_streak=true">
     </picture>
   </a>
 </p>
@@ -74,7 +73,7 @@
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://streak-stats.demolab.com?user=sudoAlphaX&theme=github-dark-blue&date_format=j%20M%5B%20Y%5D&hide_total_contributions=true&mode=daily&card_width=300">
       <source media="(prefers-color-scheme: light)" srcset="https://streak-stats.demolab.com?user=sudoAlphaX&theme=vue&date_format=j%20M%5B%20Y%5D&hide_total_contributions=true&mode=daily&card_width=300">
-      <img src="https://streak-stats.demolab.com?user=sudoAlphaX&theme=vue&date_format=j%20M%5B%20Y%5D&hide_total_contributions=true&mode=daily&card_width=300">
+      <img align="top" src="https://streak-stats.demolab.com?user=sudoAlphaX&theme=vue&date_format=j%20M%5B%20Y%5D&hide_total_contributions=true&mode=daily&card_width=300">
     </picture>
   </a>
 
@@ -82,7 +81,7 @@
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://streak-stats.demolab.com?user=sudoAlphaX&theme=github-dark-blue&date_format=j%20M%5B%20Y%5D&hide_total_contributions=true&mode=weekly&card_width=300">
       <source media="(prefers-color-scheme: light)" srcset="https://streak-stats.demolab.com?user=sudoAlphaX&theme=vue&date_format=j%20M%5B%20Y%5D&hide_total_contributions=true&mode=weekly&card_width=300">
-      <img src="https://streak-stats.demolab.com?user=sudoAlphaX&theme=vue&date_format=j%20M%5B%20Y%5D&hide_total_contributions=true&mode=weekly&card_width=300">
+      <img align="top" src="https://streak-stats.demolab.com?user=sudoAlphaX&theme=vue&date_format=j%20M%5B%20Y%5D&hide_total_contributions=true&mode=weekly&card_width=300">
     </picture>
   </a>
 </p>
@@ -95,7 +94,7 @@
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://stackoverflow-readme-profile.johannchopin.fr/profile/13303636?theme=dark&website=true&location=true">
       <source media="(prefers-color-scheme: light)" srcset="https://stackoverflow-readme-profile.johannchopin.fr/profile/13303636?theme=default&website=true&location=true">
-      <img src="https://stackoverflow-readme-profile.johannchopin.fr/profile/13303636?theme=default&website=true&location=true">
+      <img align="top" src="https://stackoverflow-readme-profile.johannchopin.fr/profile/13303636?theme=default&website=true&location=true">
     </picture>
   </a>
 </p>
@@ -104,11 +103,11 @@
 ## GitHub Contribution Graph
 
 <p>
-  <a href = "ttps://github.com/sudoAlphaX">
+  <a href = "https://github.com/sudoAlphaX">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-activity-graph.vercel.app/graph?username=sudoalphax&theme=github-dark&area=false&radius=4.5">
       <source media="(prefers-color-scheme: light)" srcset="https://github-readme-activity-graph.vercel.app/graph?username=sudoalphax&theme=github-light&area=true&radius=4.5">
-      <img src="https://github-readme-activity-graph.vercel.app/graph?username=sudoalphax&theme=github-light&area=true&radius=4.5">
+      <img align="top" src="https://github-readme-activity-graph.vercel.app/graph?username=sudoalphax&theme=github-light&area=true&radius=4.5">
     </picture>
   </a>
 </p>
@@ -121,7 +120,7 @@
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://lanyard.cnrad.dev/api/705624271308849224?theme=dark&bg=0d1117&showDisplayName=true&hideBadges=false&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing...">
       <source media="(prefers-color-scheme: light)" srcset="https://lanyard.cnrad.dev/api/705624271308849224?theme=light&bg=ffffff&showDisplayName=D&hideBadges=false&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing...">
-      <img height="200" width="390" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=light&bg=ffffff&showDisplayName=D&hideBadges=false&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing...">
+      <img align="top" height="200" width="390" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=light&bg=ffffff&showDisplayName=D&hideBadges=false&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing...">
     </picture>
   </a>
 </p>

--- a/STATS.md
+++ b/STATS.md
@@ -2,99 +2,126 @@
 
 ## Lifetime GitHub Stats
 
-<a href="https://github.com/sudoAlphaX#gh-dark-mode-only">
-  <img align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=github_dark&hide_border=false&include_all_commits=true&rank_icon=percentile&number_format=long&show=reviews,discussions_started,discussions_answered,prs_merged,prs_merged_percentage" />
-</a>
+<p>
+  <a href = "https://github.com/sudoAlphaX">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=github_dark&hide_border=false&include_all_commits=true&rank_icon=percentile&number_format=long&show=reviews,discussions_started,discussions_answered,prs_merged,prs_merged_percentage">
+      <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=vue&hide_border=false&include_all_commits=true&rank_icon=percentile&number_format=long&show=reviews,discussions_started,discussions_answered,prs_merged,prs_merged_percentage">
+      <img src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=vue&hide_border=false&include_all_commits=true&rank_icon=percentile&number_format=long&show=reviews,discussions_started,discussions_answered,prs_merged,prs_merged_percentage">
+    </picture>
+  </a>
+</p>
 
-<a href="https://github.com/sudoAlphaX#gh-light-mode-only">
-  <img align="top" src="https://github-readme-stats.vercel.app/api?username=sudoAlphaX&show_icons=true&theme=vue&hide_border=false&include_all_commits=true&rank_icon=percentile&number_format=long&show=reviews,discussions_started,discussions_answered,prs_merged,prs_merged_percentage" />
-</a>
 
 ## Most Used Languages
 
-<a href="https://github.com/sudoAlphaX#gh-dark-mode-only">
-  <img height="350" align="top" src="https://github-readme-stats.vercel.app/api/top-langs/?username=sudoalphax&custom_title=Alpha&apos;s%20Most%20Used%20Languages&layout=normal&langs_count=10&theme=github_dark&card_width=300" />
-</a>
-<a href="https://github.com/sudoAlphaX#gh-dark-mode-only">
-  <img height="350" align="top" src="https://github-readme-stats.vercel.app/api/top-langs/?username=sudoalphax&custom_title=Alpha&apos;s%20Most%20Used%20Languages&layout=donut-vertical&langs_count=10&theme=github_dark" />
-</a>
+<p>
+  <a href = "https://github.com/sudoAlphaX">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=sudoalphax&custom_title=Alpha&apos;s%20Most%20Used%20Languages&layout=normal&langs_count=10&theme=github_dark&card_width=300">
+      <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=sudoalphax&custom_title=Alpha&apos;s%20Most%20Used%20Languages&layout=normal&langs_count=10&theme=vue&card_width=300">
+      <img height="350" src="https://github-readme-stats.vercel.app/api/top-langs/?username=sudoalphax&custom_title=Alpha&apos;s%20Most%20Used%20Languages&layout=normal&langs_count=10&theme=vue&card_width=300">
+    </picture>
+  </a>
 
-<a href="https://github.com/sudoAlphaX#gh-light-mode-only">
-  <img height="350" align="top" src="https://github-readme-stats.vercel.app/api/top-langs/?username=sudoalphax&custom_title=Alpha&apos;s%20Most%20Used%20Languages&layout=normal&langs_count=10&theme=vue&card_width=300" />
-</a>
-<a href="https://github.com/sudoAlphaX#gh-light-mode-only">
-  <img height="350" align="top" src="https://github-readme-stats.vercel.app/api/top-langs/?username=sudoalphax&custom_title=Alpha&apos;s%20Most%20Used%20Languages&layout=donut-vertical&langs_count=10&theme=vue" />
-</a>
+  <a href = "https://github.com/sudoAlphaX">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=sudoalphax&custom_title=Alpha&apos;s%20Most%20Used%20Languages&layout=donut-vertical&langs_count=10&theme=github_dark">
+      <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=sudoalphax&custom_title=Alpha&apos;s%20Most%20Used%20Languages&layout=donut-vertical&langs_count=10&theme=vue">
+      <img height="350" src="https://github-readme-stats.vercel.app/api/top-langs/?username=sudoalphax&custom_title=Alpha&apos;s%20Most%20Used%20Languages&layout=donut-vertical&langs_count=10&theme=vue" >
+    </picture>
+  </a>
+</p>
+
 
 ## WakaTime Stats
 
-<a href="https://wakatime.com/@sudoAlphaX#gh-dark-mode-only">
-  <img align="top" src="https://github-readme-stats.vercel.app/api/wakatime?username=sudoAlphaX&theme=github_dark&custom_title=Alpha&apos;s%20WakaTime%20Stats&layout=default&langs_count=10" />
-</a>
-<a href="https://wakatime.com/@sudoAlphaX#gh-dark-mode-only">
-  <img align="top" src="https://github-readme-stats.vercel.app/api/wakatime?username=sudoAlphaX&theme=github_dark&custom_title=Alpha&apos;s%20WakaTime%20Stats&layout=compact&display_format=percent&langs_count=10" />
-</a>
+<p>
+  <a href = "https://wakatime.com/@sudoAlphaX">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api/wakatime?username=sudoAlphaX&theme=github_dark&custom_title=Alpha&apos;s%20WakaTime%20Stats&layout=default&langs_count=10">
+      <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api/wakatime?username=sudoAlphaX&theme=vue&custom_title=Alpha&apos;s%20Wakatime%20Stats&layout=default%display_format=time&langs_count=10">
+      <img src="https://github-readme-stats.vercel.app/api/wakatime?username=sudoAlphaX&theme=vue&custom_title=Alpha&apos;s%20Wakatime%20Stats&layout=default%display_format=time&langs_count=10">
+    </picture>
+  </a>
 
-<a href="https://wakatime.com/@sudoAlphaX#gh-light-mode-only">
-  <img align="top" src="https://github-readme-stats.vercel.app/api/wakatime?username=sudoAlphaX&theme=vue&custom_title=Alpha&apos;s%20Wakatime%20Stats&layout=default%display_format=time&langs_count=10" />
-</a>
-<a href="https://wakatime.com/@sudoAlphaX#gh-light-mode-only">
-  <img align="top" src="https://github-readme-stats.vercel.app/api/wakatime?username=sudoAlphaX&theme=vue&custom_title=Alpha&apos;s%20WakaTime%20Stats&layout=compact&display_format=percent&langs_count=10" />
-</a>
+  <a href = "https://wakatime.com/@sudoAlphaX">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api/wakatime?username=sudoAlphaX&theme=github_dark&custom_title=Alpha&apos;s%20WakaTime%20Stats&layout=compact&display_format=percent&langs_count=10">
+      <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api/wakatime?username=sudoAlphaX&theme=vue&custom_title=Alpha&apos;s%20WakaTime%20Stats&layout=compact&display_format=percent&langs_count=10">
+      <img src="https://github-readme-stats.vercel.app/api/wakatime?username=sudoAlphaX&theme=vue&custom_title=Alpha&apos;s%20WakaTime%20Stats&layout=compact&display_format=percent&langs_count=10">
+    </picture>
+  </a>
+</p>
 
 
 ## Total Contributions
 
-<a href="https://github.com/sudoAlphaX#gh-dark-mode-only">
-  <img align="top" src="https://streak-stats.demolab.com?user=sudoAlphaX&theme=github-dark-blue&date_format=j%20M%5B%20Y%5D&card_width=300&hide_current_streak=true&hide_longest_streak=true" />
-</a>
-
-<a href="https://github.com/sudoAlphaX#gh-light-mode-only">
-  <img align="top" src="https://streak-stats.demolab.com?user=sudoAlphaX&theme=vue&date_format=j%20M%5B%20Y%5D&card_width=300&hide_current_streak=true&hide_longest_streak=true" />
-</a>
+<p>
+  <a href = "https://github.com/sudoAlphaX">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://streak-stats.demolab.com?user=sudoAlphaX&theme=github-dark-blue&date_format=j%20M%5B%20Y%5D&card_width=300&hide_current_streak=true&hide_longest_streak=true">
+      <source media="(prefers-color-scheme: light)" srcset="https://streak-stats.demolab.com?user=sudoAlphaX&theme=vue&date_format=j%20M%5B%20Y%5D&card_width=300&hide_current_streak=true&hide_longest_streak=true">
+      <img src="https://streak-stats.demolab.com?user=sudoAlphaX&theme=vue&date_format=j%20M%5B%20Y%5D&card_width=300&hide_current_streak=true&hide_longest_streak=true">
+    </picture>
+  </a>
+</p>
 
 ## GitHub Streak
 
-<a href="https://github.com/sudoAlphaX#gh-dark-mode-only">
-  <img align="top" src="https://streak-stats.demolab.com?user=sudoAlphaX&theme=github-dark-blue&date_format=j%20M%5B%20Y%5D&hide_total_contributions=true&mode=daily&card_width=300" />
-</a>
-<a href="https://github.com/sudoAlphaX#gh-dark-mode-only">
-  <img align="top" src="https://streak-stats.demolab.com?user=sudoAlphaX&theme=github-dark-blue&date_format=j%20M%5B%20Y%5D&hide_total_contributions=true&mode=weekly&card_width=300"/>
-</a>
+<p>
+  <a href = "https://github.com/sudoAlphaX">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://streak-stats.demolab.com?user=sudoAlphaX&theme=github-dark-blue&date_format=j%20M%5B%20Y%5D&hide_total_contributions=true&mode=daily&card_width=300">
+      <source media="(prefers-color-scheme: light)" srcset="https://streak-stats.demolab.com?user=sudoAlphaX&theme=vue&date_format=j%20M%5B%20Y%5D&hide_total_contributions=true&mode=daily&card_width=300">
+      <img src="https://streak-stats.demolab.com?user=sudoAlphaX&theme=vue&date_format=j%20M%5B%20Y%5D&hide_total_contributions=true&mode=daily&card_width=300">
+    </picture>
+  </a>
 
-<a href="https://github.com/sudoAlphaX#gh-light-mode-only">
-  <img align="top" src="https://streak-stats.demolab.com?user=sudoAlphaX&theme=vue&date_format=j%20M%5B%20Y%5D&hide_total_contributions=true&mode=daily&card_width=300" />
-</a>
-<a href="https://github.com/sudoAlphaX#gh-light-mode-only">
-  <img align="top" src="https://streak-stats.demolab.com?user=sudoAlphaX&theme=vue&date_format=j%20M%5B%20Y%5D&hide_total_contributions=true&mode=weekly&card_width=300"/>
-</a>
+  <a href = "https://github.com/sudoAlphaX">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://streak-stats.demolab.com?user=sudoAlphaX&theme=github-dark-blue&date_format=j%20M%5B%20Y%5D&hide_total_contributions=true&mode=weekly&card_width=300">
+      <source media="(prefers-color-scheme: light)" srcset="https://streak-stats.demolab.com?user=sudoAlphaX&theme=vue&date_format=j%20M%5B%20Y%5D&hide_total_contributions=true&mode=weekly&card_width=300">
+      <img src="https://streak-stats.demolab.com?user=sudoAlphaX&theme=vue&date_format=j%20M%5B%20Y%5D&hide_total_contributions=true&mode=weekly&card_width=300">
+    </picture>
+  </a>
+</p>
 
-## Stack Overflow Stats
 
-<a href="https://stackoverflow.com/users/13303636#gh-dark-mode-only">
-  <img align="top" src="https://stackoverflow-readme-profile.johannchopin.fr/profile/13303636?theme=dark&website=true&location=true"/>
-</a>
+## Stack Overflow Details
 
-<a href="https://stackoverflow.com/users/13303636#gh-light-mode-only">
-  <img align="top" src="https://stackoverflow-readme-profile.johannchopin.fr/profile/13303636?theme=default&website=true&location=true"/>
-</a>
+<p>
+  <a href = "https://stackoverflow.com/users/13303636">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://stackoverflow-readme-profile.johannchopin.fr/profile/13303636?theme=dark&website=true&location=true">
+      <source media="(prefers-color-scheme: light)" srcset="https://stackoverflow-readme-profile.johannchopin.fr/profile/13303636?theme=default&website=true&location=true">
+      <img src="https://stackoverflow-readme-profile.johannchopin.fr/profile/13303636?theme=default&website=true&location=true">
+    </picture>
+  </a>
+</p>
+
 
 ## GitHub Contribution Graph
 
-<a href="https://github.com/sudoAlphaX#gh-dark-mode-only">
-  <img align="top" src="https://github-readme-activity-graph.vercel.app/graph?username=sudoalphax&theme=github-dark&area=false&radius=4.5"/>
-</a>
+<p>
+  <a href = "ttps://github.com/sudoAlphaX">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-activity-graph.vercel.app/graph?username=sudoalphax&theme=github-dark&area=false&radius=4.5">
+      <source media="(prefers-color-scheme: light)" srcset="https://github-readme-activity-graph.vercel.app/graph?username=sudoalphax&theme=github-light&area=true&radius=4.5">
+      <img src="https://github-readme-activity-graph.vercel.app/graph?username=sudoalphax&theme=github-light&area=true&radius=4.5">
+    </picture>
+  </a>
+</p>
 
-<a href="https://github.com/sudoAlphaX#gh-light-mode-only">
-  <img align="top" src="https://github-readme-activity-graph.vercel.app/graph?username=sudoalphax&theme=github-light&area=true&radius=4.5"/>
-</a>
 
 ## Discord Status
 
-<a href= "https://discord.com/users/705624271308849224#gh-dark-mode-only">
-  <img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=dark&bg=0d1117&showDisplayName=true&hideBadges=false&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing..." />
-</a>
-
-<a href= "https://discord.com/users/705624271308849224#gh-light-mode-only">
-  <img height="200" width="390" align="top" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=light&bg=ffffff&showDisplayName=D&hideBadges=false&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing..." />
-</a>
+<p>
+  <a href = "https://discord.com/users/705624271308849224">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://lanyard.cnrad.dev/api/705624271308849224?theme=dark&bg=0d1117&showDisplayName=true&hideBadges=false&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing...">
+      <source media="(prefers-color-scheme: light)" srcset="https://lanyard.cnrad.dev/api/705624271308849224?theme=light&bg=ffffff&showDisplayName=D&hideBadges=false&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing...">
+      <img height="200" width="390" src="https://lanyard.cnrad.dev/api/705624271308849224?theme=light&bg=ffffff&showDisplayName=D&hideBadges=false&animated=true&borderRadius=4.5px&idleMessage=Currently%20sudoAlphing...">
+    </picture>
+  </a>
+</p>


### PR DESCRIPTION
remove #gh-dark-mode-only and #gh-light-mode-only because deprecated soon and use <picture> element and <source media="(prefers-color-scheme: light)">